### PR TITLE
Add development-only route logging wrappers

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -118,6 +118,21 @@ docker-compose logs -f
 docker-compose logs -f policy-backend
 ```
 
+## Express ルートデバッグフック (開発専用)
+
+`idea-discussion` と `policy-edit` のバックエンドでは、`NODE_ENV` が
+`production` でない場合に、`app.use` や `app.get` などのルート登録メソッドを
+ラップして `[ROUTE-DEBUG]` ログを出力します。これにより、どのミドルウェアや
+ルートハンドラーが問題のリクエストを受け取っているかを追跡できます。
+
+- **無効化するには**: 該当プロセスを `NODE_ENV=production` で起動するか、
+  ブートストラップファイル (`idea-discussion/backend/server.js` および
+  `policy-edit/backend/src/index.ts`) のコメント付きデバッグブロックを削除し
+  てください。
+- **削除の目安**: 想定外のルート呼び出しの原因が特定できたら、このフックを
+  取り除いて通常運用に戻してください。生産環境では実行されないため、既存の
+  本番ビルドには影響しません。
+
 ## 環境の停止
 
 実行中のサービスを停止し、コンテナ、ネットワークを削除するには（名前付きボリューム `mongo_data` は保持されます）:

--- a/idea-discussion/backend/server.js
+++ b/idea-discussion/backend/server.js
@@ -29,6 +29,31 @@ try {
 
 // --- Express App Setup ---
 const app = express();
+
+// Temporary debug hook to trace route registration in non-production builds.
+// Remove or disable this block once the unexpected route invocation has been
+// identified. Production builds never execute this block.
+if (process.env.NODE_ENV !== "production") {
+  const routeDebugMethods = [
+    "use",
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "all",
+  ];
+
+  for (const methodName of routeDebugMethods) {
+    const originalMethod = app[methodName].bind(app);
+
+    app[methodName] = (...args) => {
+      const [firstArg] = args;
+      console.log("[ROUTE-DEBUG]", methodName.toUpperCase(), firstArg);
+      return originalMethod(...args);
+    };
+  }
+}
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {


### PR DESCRIPTION
## Summary
- wrap Express route registration methods in development builds to log the verb and first argument
- ensure both idea-discussion and policy-edit backends retain original middleware behavior
- document how to disable the temporary route debug hook for future clean-up

## Testing
- npm run lint *(fails: biome command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca63481860832da9c4c10d9b88db38