### PR TITLE
Normalize configurable API mounts

### DIFF
--- a/idea-discussion/backend/server.js
+++ b/idea-discussion/backend/server.js
@@ -88,8 +88,10 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // --- API Routes ---
+const apiRouter = express.Router();
+
 // Health Check Endpoint
-app.get(withApiMount("/health"), (req, res) => {
+apiRouter.get("/health", (req, res) => {
   res.json({ status: "ok", timestamp: new Date() });
 });
 
@@ -111,32 +113,34 @@ import topPageRoutes from "./routes/topPageRoutes.js"; // Import top page routes
 import userRoutes from "./routes/userRoutes.js"; // Import user routes
 
 // Theme management routes
-app.use(withApiMount("/themes"), themeRoutes);
+apiRouter.use("/themes", themeRoutes);
 
-app.use(withApiMount("/auth"), authRoutes);
+apiRouter.use("/auth", authRoutes);
 
-app.use(withApiMount("/themes/:themeId/questions"), themeQuestionRoutes);
-app.use(withApiMount("/themes/:themeId/problems"), themeProblemRoutes);
-app.use(withApiMount("/themes/:themeId/solutions"), themeSolutionRoutes);
-app.use(
-  withApiMount("/themes/:themeId/generate-questions"),
+apiRouter.use("/themes/:themeId/questions", themeQuestionRoutes);
+apiRouter.use("/themes/:themeId/problems", themeProblemRoutes);
+apiRouter.use("/themes/:themeId/solutions", themeSolutionRoutes);
+apiRouter.use(
+  "/themes/:themeId/generate-questions",
   themeGenerateQuestionsRoutes
 );
-app.use(withApiMount("/themes/:themeId/policy-drafts"), themePolicyRoutes);
-app.use(withApiMount("/themes/:themeId/digest-drafts"), themeDigestRoutes);
-app.use(withApiMount("/themes/:themeId/import"), themeImportRoutes);
-app.use(withApiMount("/themes/:themeId/chat"), themeChatRoutes);
-app.use(withApiMount("/themes/:themeId"), themeEmbeddingRoutes);
-app.use(withApiMount("/questions/:questionId"), questionEmbeddingRoutes);
+apiRouter.use("/themes/:themeId/policy-drafts", themePolicyRoutes);
+apiRouter.use("/themes/:themeId/digest-drafts", themeDigestRoutes);
+apiRouter.use("/themes/:themeId/import", themeImportRoutes);
+apiRouter.use("/themes/:themeId/chat", themeChatRoutes);
+apiRouter.use("/themes/:themeId", themeEmbeddingRoutes);
+apiRouter.use("/questions/:questionId", questionEmbeddingRoutes);
 
-app.use(withApiMount("/site-config"), siteConfigRoutes);
-app.use(withApiMount("/top-page-data"), topPageRoutes); // Add top page routes
-app.use(withApiMount("/users"), userRoutes);
-app.use(withApiMount("/likes"), likeRoutes);
-app.use(
-  withApiMount("/uploads"),
+apiRouter.use("/site-config", siteConfigRoutes);
+apiRouter.use("/top-page-data", topPageRoutes); // Add top page routes
+apiRouter.use("/users", userRoutes);
+apiRouter.use("/likes", likeRoutes);
+apiRouter.use(
+  "/uploads",
   express.static(path.join(__dirname, "uploads"))
 );
+
+app.use(API_MOUNT, apiRouter);
 
 // Helper to check whether a request path is scoped to the API mount
 const isApiRequestPath = (requestPath) =>

--- a/policy-edit/backend/src/index.ts
+++ b/policy-edit/backend/src/index.ts
@@ -10,10 +10,7 @@ import cors from "cors";
 import express from "express";
 import { CORS_ORIGIN, PORT } from "./config.js";
 import chatRoutes from "./routes/chat.js";
-import {
-  createMountPathJoiner,
-  normalizeMountPath,
-} from "./utils/mountPath.js";
+import { normalizeMountPath } from "./utils/mountPath.js";
 import { logger } from "./utils/logger.js";
 
 const fallbackApiMount = (() => {
@@ -37,8 +34,6 @@ const API_MOUNT = normalizeMountPath(
   process.env.API_MOUNT_PATH ?? fallbackApiMount
 );
 
-const withApiMount = createMountPathJoiner(API_MOUNT);
-
 logger.info(`Using API mount path: ${API_MOUNT}`);
 
 // Create Express app
@@ -54,16 +49,15 @@ app.use(
   })
 );
 
-// Routes
-app.use(withApiMount("/chat"), chatRoutes);
+const apiRouter = express.Router();
 
-// Health check endpoint
-app.get(withApiMount("/health"), (
-  _req: express.Request,
-  res: express.Response
-) => {
+apiRouter.use("/chat", chatRoutes);
+
+apiRouter.get("/health", (_req: express.Request, res: express.Response) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
+
+app.use(API_MOUNT, apiRouter);
 
 // Error handling middleware
 app.use(

--- a/policy-edit/backend/src/index.ts
+++ b/policy-edit/backend/src/index.ts
@@ -10,7 +10,10 @@ import cors from "cors";
 import express from "express";
 import { CORS_ORIGIN, PORT } from "./config.js";
 import chatRoutes from "./routes/chat.js";
-import { normalizeMountPath } from "./utils/mountPath.js";
+import {
+  createMountPathJoiner,
+  normalizeMountPath,
+} from "./utils/mountPath.js";
 import { logger } from "./utils/logger.js";
 
 const fallbackApiMount = (() => {
@@ -34,6 +37,8 @@ const API_MOUNT = normalizeMountPath(
   process.env.API_MOUNT_PATH ?? fallbackApiMount
 );
 
+const withApiMount = createMountPathJoiner(API_MOUNT);
+
 logger.info(`Using API mount path: ${API_MOUNT}`);
 
 // Create Express app
@@ -49,17 +54,16 @@ app.use(
   })
 );
 
-const apiRouter = express.Router();
-
 // Routes
-apiRouter.use("/chat", chatRoutes);
+app.use(withApiMount("/chat"), chatRoutes);
 
 // Health check endpoint
-apiRouter.get("/health", (_req: express.Request, res: express.Response) => {
+app.get(withApiMount("/health"), (
+  _req: express.Request,
+  res: express.Response
+) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
-
-app.use(API_MOUNT, apiRouter);
 
 // Error handling middleware
 app.use(

--- a/policy-edit/backend/src/utils/mountPath.js
+++ b/policy-edit/backend/src/utils/mountPath.js
@@ -1,0 +1,43 @@
+// This file mirrors the logic in mountPath.ts so that JavaScript-only
+// consumers (e.g. the idea-discussion backend) can share the same helper.
+const DEFAULT_MOUNT_PATH = "/api";
+const PLACEHOLDER_BASE_URL = "http://placeholder.local";
+
+export function normalizeMountPath(rawPath) {
+  if (rawPath == null) {
+    return DEFAULT_MOUNT_PATH;
+  }
+
+  const trimmed = String(rawPath).trim();
+  if (trimmed === "") {
+    return DEFAULT_MOUNT_PATH;
+  }
+
+  let candidate = trimmed;
+
+  try {
+    const parsed = trimmed.includes("://") || trimmed.startsWith("//")
+      ? new URL(trimmed)
+      : new URL(trimmed, PLACEHOLDER_BASE_URL);
+    candidate = parsed.pathname;
+  } catch (error) {
+    // Ignore parse errors and fall back to the raw trimmed value.
+  }
+
+  candidate = candidate.replace(/\\+/g, "/");
+  let normalized = candidate.replace(/\/+/g, "/");
+
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+
+  if (normalized.length > 1) {
+    normalized = normalized.replace(/\/+$/u, "");
+  }
+
+  if (normalized === "" || normalized === "/") {
+    return normalized === "" ? DEFAULT_MOUNT_PATH : "/";
+  }
+
+  return normalized;
+}

--- a/policy-edit/backend/src/utils/mountPath.js
+++ b/policy-edit/backend/src/utils/mountPath.js
@@ -3,6 +3,19 @@
 const DEFAULT_MOUNT_PATH = "/api";
 const PLACEHOLDER_BASE_URL = "http://placeholder.local";
 
+function normalizeRoutePath(routePath) {
+  const trimmed = String(routePath).trim();
+  if (trimmed === "") {
+    return "/";
+  }
+
+  if (trimmed === "/") {
+    return "/";
+  }
+
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
 export function normalizeMountPath(rawPath) {
   if (rawPath == null) {
     return DEFAULT_MOUNT_PATH;
@@ -40,4 +53,40 @@ export function normalizeMountPath(rawPath) {
   }
 
   return normalized;
+}
+
+export function joinMountPath(mountPath, routePath = "/") {
+  const normalizedMount = normalizeMountPath(mountPath);
+  const normalizedRoute = normalizeRoutePath(routePath);
+
+  if (normalizedRoute === "/") {
+    return normalizedMount;
+  }
+
+  if (normalizedMount === "/") {
+    return normalizedRoute;
+  }
+
+  return `${normalizedMount}${normalizedRoute}`;
+}
+
+export function createMountPathJoiner(mountPath) {
+  const normalizedMount = normalizeMountPath(mountPath);
+
+  return (routePath = "/") => joinMountPath(normalizedMount, routePath);
+}
+
+export function isWithinMountPath(mountPath, requestPath) {
+  const normalizedMount = normalizeMountPath(mountPath);
+
+  if (normalizedMount === "/") {
+    return true;
+  }
+
+  const normalizedRequest = normalizeRoutePath(requestPath);
+
+  return (
+    normalizedRequest === normalizedMount ||
+    normalizedRequest.startsWith(`${normalizedMount}/`)
+  );
 }

--- a/policy-edit/backend/src/utils/mountPath.ts
+++ b/policy-edit/backend/src/utils/mountPath.ts
@@ -2,22 +2,36 @@ const DEFAULT_MOUNT_PATH = "/api";
 
 const PLACEHOLDER_BASE_URL = "http://placeholder.local";
 
+function normalizeRoutePath(routePath: string | null | undefined): string {
+  const trimmed = (routePath ?? "").trim();
+  if (trimmed === "") {
+    return "/";
+  }
+
+  if (trimmed === "/") {
+    return "/";
+  }
+
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
 export function normalizeMountPath(rawPath?: string | null): string {
   if (rawPath == null) {
     return DEFAULT_MOUNT_PATH;
   }
 
-  const trimmed = rawPath.trim();
-  if (trimmed === "") {
+  const trimmedInput = rawPath.trim();
+  if (trimmedInput === "") {
     return DEFAULT_MOUNT_PATH;
   }
 
-  let candidate = trimmed;
+  let candidate = trimmedInput;
 
   try {
-    const parsed = trimmed.includes("://") || trimmed.startsWith("//")
-      ? new URL(trimmed)
-      : new URL(trimmed, PLACEHOLDER_BASE_URL);
+    const parsed =
+      trimmedInput.includes("://") || trimmedInput.startsWith("//")
+        ? new URL(trimmedInput)
+        : new URL(trimmedInput, PLACEHOLDER_BASE_URL);
     candidate = parsed.pathname;
   } catch (error) {
     // Ignore parse errors and fall back to the raw trimmed value.
@@ -41,4 +55,46 @@ export function normalizeMountPath(rawPath?: string | null): string {
   }
 
   return normalized;
+}
+
+export function joinMountPath(
+  mountPath: string,
+  routePath: string | null | undefined = "/"
+): string {
+  const normalizedMount = normalizeMountPath(mountPath);
+  const normalizedRoute = normalizeRoutePath(routePath);
+
+  if (normalizedRoute === "/") {
+    return normalizedMount;
+  }
+
+  if (normalizedMount === "/") {
+    return normalizedRoute;
+  }
+
+  return `${normalizedMount}${normalizedRoute}`;
+}
+
+export function createMountPathJoiner(mountPath: string) {
+  const normalizedMount = normalizeMountPath(mountPath);
+
+  return (routePath: string = "/") => joinMountPath(normalizedMount, routePath);
+}
+
+export function isWithinMountPath(
+  mountPath: string,
+  requestPath: string | null | undefined
+): boolean {
+  const normalizedMount = normalizeMountPath(mountPath);
+
+  if (normalizedMount === "/") {
+    return true;
+  }
+
+  const normalizedRequest = normalizeRoutePath(requestPath);
+
+  return (
+    normalizedRequest === normalizedMount ||
+    normalizedRequest.startsWith(`${normalizedMount}/`)
+  );
 }

--- a/policy-edit/backend/src/utils/mountPath.ts
+++ b/policy-edit/backend/src/utils/mountPath.ts
@@ -1,0 +1,44 @@
+const DEFAULT_MOUNT_PATH = "/api";
+
+const PLACEHOLDER_BASE_URL = "http://placeholder.local";
+
+export function normalizeMountPath(rawPath?: string | null): string {
+  if (rawPath == null) {
+    return DEFAULT_MOUNT_PATH;
+  }
+
+  const trimmed = rawPath.trim();
+  if (trimmed === "") {
+    return DEFAULT_MOUNT_PATH;
+  }
+
+  let candidate = trimmed;
+
+  try {
+    const parsed = trimmed.includes("://") || trimmed.startsWith("//")
+      ? new URL(trimmed)
+      : new URL(trimmed, PLACEHOLDER_BASE_URL);
+    candidate = parsed.pathname;
+  } catch (error) {
+    // Ignore parse errors and fall back to the raw trimmed value.
+  }
+
+  // Normalize path separators and collapse duplicate slashes to avoid paths
+  // like //foo or /foo//bar.
+  candidate = candidate.replace(/\\+/g, "/");
+  let normalized = candidate.replace(/\/+/g, "/");
+
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+
+  if (normalized.length > 1) {
+    normalized = normalized.replace(/\/+$/u, "");
+  }
+
+  if (normalized === "" || normalized === "/") {
+    return normalized === "" ? DEFAULT_MOUNT_PATH : "/";
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- add a shared mount-path normalizer utility for consistent API prefixes
- mount the policy-edit backend routes beneath the computed API base path
- refactor the idea-discussion backend to share the same mount and router structure

## Testing
- npm run typecheck --workspace policy-edit/backend *(fails: missing workspace dependencies such as dotenv and express types)*
- npm run test --workspace idea-discussion/backend *(fails: missing workspace dependency dotenv during vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6346f5c8832db968830d3f18e930