### PR TITLE
Add API mount path configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # GitHub Mock Client Configuration
 # Set to true to use mock GitHub client instead of real GitHub API (useful for development to avoid rate limits)
 VITE_USE_MOCK_GITHUB_CLIENT=false
+
+# Backend API mount path
+# Accepts "/" for root or an absolute path like "/api". Leading/trailing whitespace is trimmed and
+# redundant slashes at the end are removed when the value is parsed, and a missing leading slash is added automatically.
+API_MOUNT_PATH=/api

--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,10 @@
 # サーバーの実行環境を指定します (開発時: development, 本番時: production)
 NODE_ENV=development
 
+# Backend API のマウントパスを指定します。"/" または "/api" のような先頭がスラッシュの値を設定してください。
+# 値の前後の空白は自動的に取り除かれ、先頭のスラッシュが無い場合は付与、末尾の余分なスラッシュは削除されます。
+API_MOUNT_PATH=/api
+
 ## OpenRouter API 設定
 # LLM (AIモデル) との通信に使用するOpenRouter APIキーです。
 # ★ 必須：[openrouterのサイト](https://openrouter.ai/) で取得したキーを設定してください。

--- a/policy-edit/backend/src/config.ts
+++ b/policy-edit/backend/src/config.ts
@@ -13,6 +13,43 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 export const PORT = process.env.PORT || 3001;
 export const NODE_ENV = process.env.NODE_ENV || "development";
 
+const DEFAULT_API_MOUNT_PATH = "/api";
+
+const normaliseApiMountPath = (value?: string): string => {
+  if (!value) {
+    return DEFAULT_API_MOUNT_PATH;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed === "") {
+    return DEFAULT_API_MOUNT_PATH;
+  }
+
+  if (trimmed === "/") {
+    return "/";
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/")
+    ? trimmed
+    : `/${trimmed}`;
+
+  const collapsedSlashes = withLeadingSlash.replace(/\/{2,}/g, "/");
+
+  const withoutTrailingSlash =
+    collapsedSlashes.length > 1
+      ? collapsedSlashes.replace(/\/+$/, "")
+      : collapsedSlashes;
+
+  const normalised = withoutTrailingSlash || DEFAULT_API_MOUNT_PATH;
+
+  return normalised === "" ? DEFAULT_API_MOUNT_PATH : normalised;
+};
+
+export const API_MOUNT_PATH = normaliseApiMountPath(
+  process.env.API_MOUNT_PATH
+);
+
 // OpenRouter API configuration
 export const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 

--- a/policy-edit/backend/src/index.ts
+++ b/policy-edit/backend/src/index.ts
@@ -8,7 +8,7 @@ console.log("------------------------------------");
 import cors from "cors";
 // --- END DEBUG ---
 import express from "express";
-import { CORS_ORIGIN, PORT } from "./config.js";
+import { API_MOUNT_PATH, CORS_ORIGIN, PORT } from "./config.js";
 import chatRoutes from "./routes/chat.js";
 import { logger } from "./utils/logger.js";
 
@@ -26,10 +26,13 @@ app.use(
 );
 
 // Routes
-app.use("/chat", chatRoutes);
+const apiRoute = (suffix: string) =>
+  `${API_MOUNT_PATH === "/" ? "" : API_MOUNT_PATH}${suffix}`;
+
+app.use(apiRoute("/chat"), chatRoutes);
 
 // Health check endpoint
-app.get("/health", (req, res) => {
+app.get(apiRoute("/health"), (req, res) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
@@ -53,6 +56,7 @@ app.use(
 app.listen(PORT, () => {
   logger.info(`Server running on port ${PORT}`);
   logger.info(`CORS enabled for origin: ${CORS_ORIGIN}`);
+  logger.info(`API routes mounted at: ${API_MOUNT_PATH}`);
 });
 
 // Handle graceful shutdown

--- a/policy-edit/backend/src/routes/chat.ts
+++ b/policy-edit/backend/src/routes/chat.ts
@@ -16,7 +16,7 @@ import { ProcessChatMessageUsecase } from "../usecases/ProcessChatMessageUsecase
 const router = express.Router();
 const mcpClientRef = { current: null as McpClient | null };
 
-// POST /api/chat - Process a chat message
+// POST {API_MOUNT_PATH}/chat - Process a chat message (default mount: /api)
 router.post("/", async (req, res) => {
   if (!mcpClientRef.current) {
     return res.status(500).json({ error: "MCP client is not initialized" });
@@ -46,7 +46,7 @@ router.post("/", async (req, res) => {
   return res.json(result.value);
 });
 
-// POST /api/chat/connect - Connect to the MCP server
+// POST {API_MOUNT_PATH}/chat/connect - Connect to the MCP server (default mount: /api)
 router.post("/connect", async (req, res) => {
   const usecase = new ConnectMcpServerUsecase(mcpClientRef);
   const result = await usecase.execute();
@@ -65,7 +65,7 @@ router.post("/connect", async (req, res) => {
   return res.json(result.value);
 });
 
-// GET /api/chat/status - Check MCP client status
+// GET {API_MOUNT_PATH}/chat/status - Check MCP client status (default mount: /api)
 router.get("/status", (req, res) => {
   return res.json({
     initialized: mcpClientRef.current !== null,


### PR DESCRIPTION
## Summary
- document the new `API_MOUNT_PATH` environment variable in the shared examples, including how the value is normalised
- parse `API_MOUNT_PATH` in the policy backend configuration module with sensible defaults and sanitisation
- mount the policy backend routes using the configured API base path and update the route documentation comments

## Testing
- npm run typecheck (policy-edit/backend)


------
https://chatgpt.com/codex/tasks/task_e_68ca6349d198832db3ec23e1500461d7