### PR TITLE
feat(frontend): configure site metadata

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,9 @@
       href="https://fonts.googleapis.com/css2?family=BIZ+UDGothic:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <title>いどばたビジョン</title>
+    <meta property="og:site_name" content="広陵いどばた" />
+    <meta property="og:title" content="広陵いどばた - まちのアイデア広場" />
+    <title>広陵いどばた - まちのアイデア広場</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
-import { useSiteConfig } from "../../contexts/SiteConfigContext";
+import { SITE } from "../../config/site";
 import { Button } from "../ui/button";
 import { Sheet, SheetClose, SheetContent, SheetTrigger } from "../ui/sheet";
 // ヘッダーの高さ定数
@@ -42,8 +42,6 @@ const NAV_ITEMS = [
 
 const Header: React.FC = () => {
   const location = useLocation();
-  const { siteConfig, loading } = useSiteConfig();
-
   return (
     <header className="sticky top-0 z-50 w-full border-b-2 border-[#2D80FF] bg-white">
       <div className="flex items-center justify-between px-6 py-5 md:px-10 md:py-4">
@@ -53,9 +51,7 @@ const Header: React.FC = () => {
             to="/top"
             className="font-bold text-lg md:text-xl tracking-wider text-[#27272A] leading-none hover:text-[#2D80FF] transition-colors cursor-pointer"
           >
-            {loading
-              ? "..."
-              : siteConfig?.title || "XX党みんなの政策フォーラム"}
+            {SITE.nameJa}
           </Link>
           <div className="flex items-center gap-1">
             <span className="text-[8px] font-bold text-[#94B9F9] leading-[2em] tracking-[0.0375em]">

--- a/frontend/src/config/site.ts
+++ b/frontend/src/config/site.ts
@@ -1,0 +1,27 @@
+const getEnvValue = (key: string, fallback: string): string => {
+  const value = import.meta.env?.[key];
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return fallback;
+};
+
+export const SITE_NAME_JA = getEnvValue("VITE_SITE_NAME_JA", "広陵いどばた");
+export const SITE_NAME_EN = getEnvValue("VITE_SITE_NAME_EN", "KORYO Idobata");
+export const SITE_TAGLINE = getEnvValue(
+  "VITE_SITE_TAGLINE",
+  "まちのアイデア広場"
+);
+
+export const SITE = {
+  nameJa: SITE_NAME_JA,
+  nameEn: SITE_NAME_EN,
+  tagline: SITE_TAGLINE,
+};
+
+export const SITE_TITLE = `${SITE.nameJa} - ${SITE.tagline}`;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,25 @@ import "./index.css";
 import "./App.css";
 import "./styles/markdown.css";
 import { router } from "./App";
+import { SITE, SITE_TITLE } from "./config/site";
 import { SiteConfigProvider } from "./contexts/SiteConfigContext";
+
+const ensureMetaTag = (property: string, content: string) => {
+  const selector = `meta[property="${property}"]`;
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+
+  if (!element) {
+    element = document.createElement("meta");
+    element.setAttribute("property", property);
+    document.head.appendChild(element);
+  }
+
+  element.setAttribute("content", content);
+};
+
+document.title = SITE_TITLE;
+ensureMetaTag("og:site_name", SITE.nameJa);
+ensureMetaTag("og:title", SITE_TITLE);
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Failed to find the root element");


### PR DESCRIPTION
## Summary
- load site metadata from environment variables with sensible defaults
- update the header and runtime metadata to use the shared site configuration
- align index.html Open Graph tags and title with the configured site information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca64b881d4832d86bb917a94e15f98