### PR TITLE
feat: align frontend env variable names

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -63,12 +63,14 @@ JWT_EXPIRES_IN=1d                            # e.g., 1d, 7d, 30m
 
 # Idea Backend の基本 URL です。
 IDEA_FRONTEND_API_BASE_URL=http://localhost:3000
+VITE_IDEA_FRONTEND_API_BASE_URL=http://localhost:3000
 
 # Policy Backend  の基本 URL です。
 # Backend の OGP ルーターが /api にマウントされている場合、Frontend から呼び出す際は /api を含める必要があります。
 POLICY_FRONTEND_API_BASE_URL=http://localhost:3001
 # Admin Backend の基本 URL です。
 ADMIN_API_BASE_URL=http://localhost:3000
+VITE_ADMIN_FRONTEND_API_BASE_URL=http://localhost:3000
 
 # CORS Settings for microservices
 IDEA_CORS_ORIGIN=http://localhost:5173,http://localhost:5175

--- a/admin/src/services/api/apiClient.ts
+++ b/admin/src/services/api/apiClient.ts
@@ -23,7 +23,21 @@ export class ApiClient {
   private baseUrl: string;
 
   constructor() {
-    this.baseUrl = `${import.meta.env.VITE_API_BASE_URL}/api`;
+    const rawBaseUrl = import.meta.env.VITE_ADMIN_FRONTEND_API_BASE_URL;
+    if (!rawBaseUrl) {
+      throw new Error("VITE_ADMIN_FRONTEND_API_BASE_URL is not defined");
+    }
+
+    const trimmedBaseUrl = rawBaseUrl.trim();
+    if (!trimmedBaseUrl) {
+      throw new Error("VITE_ADMIN_FRONTEND_API_BASE_URL cannot be empty");
+    }
+
+    const normalizedBaseUrl = trimmedBaseUrl.replace(/\/+$/, "");
+
+    this.baseUrl = normalizedBaseUrl.endsWith("/api")
+      ? normalizedBaseUrl
+      : `${normalizedBaseUrl}/api`;
   }
 
   private async request<T>(

--- a/admin/src/vite-env.d.ts
+++ b/admin/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 interface ImportMeta {
   readonly env: {
-    readonly VITE_API_BASE_URL: string;
+    readonly VITE_ADMIN_FRONTEND_API_BASE_URL: string;
     [key: string]: string | boolean | undefined;
   };
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - .env
     environment:
       - NODE_ENV=development
-      - VITE_API_BASE_URL=${IDEA_FRONTEND_API_BASE_URL} # 初期段階ではidea-discussionのAPIを使用
+      - VITE_IDEA_FRONTEND_API_BASE_URL=${IDEA_FRONTEND_API_BASE_URL} # 初期段階ではidea-discussionのAPIを使用
       - VITE_FRONTEND_ALLOWED_HOSTS=${VITE_FRONTEND_ALLOWED_HOSTS}
 
   # --- Database ---
@@ -153,7 +153,7 @@ services:
       - .env
     environment:
       - NODE_ENV=development
-      - VITE_API_BASE_URL=${ADMIN_API_BASE_URL} # idea-discussionバックエンドを指す
+      - VITE_ADMIN_FRONTEND_API_BASE_URL=${ADMIN_API_BASE_URL} # idea-discussionバックエンドを指す
       - VITE_ADMIN_FRONTEND_ALLOWED_HOSTS=${VITE_ADMIN_FRONTEND_ALLOWED_HOSTS}
       - VITE_ALLOW_DELETE_THEME=${ALLOW_DELETE_THEME}
 

--- a/frontend/src/services/api/apiClient.ts
+++ b/frontend/src/services/api/apiClient.ts
@@ -46,7 +46,21 @@ export class ApiClient {
   private retryOptions: RetryOptions;
 
   constructor() {
-    const baseUrl = `${import.meta.env.VITE_API_BASE_URL}/api`;
+    const rawBaseUrl = import.meta.env.VITE_IDEA_FRONTEND_API_BASE_URL;
+    if (!rawBaseUrl) {
+      throw new Error("VITE_IDEA_FRONTEND_API_BASE_URL is not defined");
+    }
+
+    const trimmedBaseUrl = rawBaseUrl.trim();
+    if (!trimmedBaseUrl) {
+      throw new Error("VITE_IDEA_FRONTEND_API_BASE_URL cannot be empty");
+    }
+
+    const normalizedBaseUrl = trimmedBaseUrl.replace(/\/+$/, "");
+    const baseUrl = normalizedBaseUrl.endsWith("/api")
+      ? normalizedBaseUrl
+      : `${normalizedBaseUrl}/api`;
+
     this.httpClient = new HttpClient({
       baseUrl,
       timeout: 30000,

--- a/frontend/src/services/socket/socketClient.ts
+++ b/frontend/src/services/socket/socketClient.ts
@@ -35,10 +35,18 @@ class SocketClient {
       return;
     }
 
-    const baseUrl =
+    const rawBaseUrl =
       typeof import.meta.env !== "undefined"
-        ? import.meta.env.VITE_API_BASE_URL || ""
+        ? import.meta.env.VITE_IDEA_FRONTEND_API_BASE_URL
         : "";
+    const trimmedBaseUrl = rawBaseUrl ? rawBaseUrl.trim() : "";
+
+    if (!trimmedBaseUrl) {
+      throw new Error("VITE_IDEA_FRONTEND_API_BASE_URL is not defined");
+    }
+
+    const baseUrl = trimmedBaseUrl.replace(/\/+$/, "");
+
     this.socket = io(baseUrl, {
       autoConnect: false,
       reconnection: true,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,7 +2,7 @@
 
 interface ImportMeta {
   readonly env: {
-    readonly VITE_API_BASE_URL: string;
+    readonly VITE_IDEA_FRONTEND_API_BASE_URL: string;
     [key: string]: string;
   };
 }


### PR DESCRIPTION
## Summary
- expose VITE_IDEA_FRONTEND_API_BASE_URL and VITE_ADMIN_FRONTEND_API_BASE_URL in the Vite env typings
- fail fast if the required env variables are missing when building API and socket clients
- rename the corresponding environment variables in .env.template and docker-compose.yml

## Testing
- npm run lint *(fails: biome not yet formatted for other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6ff6c038832d916a037d5086d82a