### PR TITLE
Adjust backend build output path

### DIFF
--- a/idea-discussion/backend/package.json
+++ b/idea-discussion/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "vitest run --passWithNoTests",
     "build": "tsc",
-    "start": "node build/server.js",
+    "start": "node ../build/server.js",
     "dev": "nodemon --exec npx ts-node server.js",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",

--- a/idea-discussion/backend/tsconfig.json
+++ b/idea-discussion/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "outDir": "./build",
+    "outDir": "../build",
     "rootDir": ".",
     "strict": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- direct the idea-discussion backend TypeScript build output to the repo-level build folder so compiled imports resolve to the expected packages
- update the backend start script to execute the server from the new build location

## Testing
- npm run -w idea-discussion/backend build *(fails: TypeScript cannot find module 'mongoose' types in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7661aa1c832d81745efe6405cec4